### PR TITLE
Fix Leaflet reference from example page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <div id="map"></div>
-    <script src="lib/leaflet/leaflet-src.js"></script>
+    <script src="lib/leaflet-0.4.5/leaflet-src.js"></script>
     <script src="lib/proj4js-compressed.js"></script>
     <script src="../src/proj4leaflet.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>


### PR DESCRIPTION
After the update to 0.4.5 the example page was broken, this fixes the
leaflet reference even though the page still seems broken in other ways.
