### PR TITLE
Removed trailing commas

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -68,7 +68,7 @@ L.Proj.CRS = L.Class.extend({
 				return 1 / this.options.resolutions[zoom];
 			}
 		}
-	},
+	}
 });
 
 L.Proj.CRS.TMS = L.Proj.CRS.extend({
@@ -89,7 +89,7 @@ L.Proj.CRS.TMS = L.Proj.CRS.extend({
 		}
 
 		this.projectedBounds = projectedBounds;
-	},
+	}
 });
 
 L.Proj.TileLayer = {};
@@ -97,7 +97,7 @@ L.Proj.TileLayer = {};
 L.Proj.TileLayer.TMS = L.TileLayer.extend({
 	options: {
 		tms: true,
-		continuousWorld: true,
+		continuousWorld: true
 	},
 
 	initialize: function(urlTemplate, crs, options) {


### PR DESCRIPTION
Trailing commas can involve errors in IE and won't work with some compilers (like Google Closure) that will just reject files that contain this kind of syntax errors
