### PR TITLE
Remove delete statement

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -282,8 +282,6 @@
 						var point = L.point(coords[0], coords[1]);
 						return crs.projection.unproject(point);
 					};
-				} else {
-					delete this.options.coordsToLatLng;
 				}
 			}
 


### PR DESCRIPTION
When calling with JSON like this (returned from a wfs server):

```
{"type":"FeatureCollection","features":[{"type":"Feature","id":"pand","geometry":{"type":"MultiPolygon","coordinates":[[[[234038.74,580648.672],[234034.874,580653.938],[234023.226,580669.804],[234018.279,580668.348],[234008.066,580665.342],[234012.423,580654.134],[234008.164,580652.906],[234010.63,580640.48],[234038.74,580648.672]]]]},"properties":{}}],"crs":{"type":"EPSG","properties":{"code":"28992"}}}
```

Line https://github.com/Leaflet/Leaflet/blob/master/src/layer/GeoJSON.js#L26 will call `L.Proj.addData` again with the first feature, but this 'sub' feature won't have a crs definition and thus the `coordsToLatLng` will be incorrectly removed.
