### PR TITLE
Fix CRS.scale to handle non-integer zoomlevels

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -126,7 +126,7 @@
 				nextScale = this._scales[iZoom + 1];
 				scaleDiff = nextScale - baseScale;
 				zDiff = (zoom - iZoom);
-				return baseScale + scaleDiff * Math.pow(zDiff, nextScale / baseScale);
+				return baseScale + scaleDiff * zDiff;
 			}
 		},
 


### PR DESCRIPTION
When pinch-zooming (and possibly other cases), Leaflet calls CRS.scale with a non-integer zoom argument. This is currently not handled by Proj4Leaflet, which causes `NaN` problems in Leaflet, so that pinch-zooming is at least partially broken if Proj4Leaflet is used.
