### PR TITLE
Better check for commonJS

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -3,7 +3,7 @@
 	if (typeof define === 'function' && define.amd) {
 		// AMD
 		define(['leaflet', 'proj4'], factory);
-	} else if (typeof module !== 'undefined') {
+	} else if (typeof module === 'object' && typeof module.exports === "object") {
 		// Node/CommonJS
 		L = require('leaflet');
 		proj4 = require('proj4');


### PR DESCRIPTION
Better check for commonJS, otherwise it also takes the QUnit module method, which causes a crash

This is the same check JQuery uses