### PR TITLE
Fix GeoJSON.initialize when no data

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -265,7 +265,9 @@
 		initialize: function(geojson, options) {
 			this._callLevel = 0;
 			L.GeoJSON.prototype.initialize.call(this, null, options);
-			this.addData(geojson);
+			if (geojson) {
+				this.addData(geojson);
+			}
 		},
 
 		addData: function(geojson) {


### PR DESCRIPTION
When you try to create a L.Proj.GeoJSON layer with no data (to add it
after layer creation):

        var layer = L.Proj.geoJson();
        layer.addData(geojson).addTo(map);

You get an exception:

        Uncaught TypeError: Cannot read property 'features' of undefined