### PR TITLE
Change the layer name in the wms example

### DIFF
--- a/examples/wms/script.js
+++ b/examples/wms/script.js
@@ -14,7 +14,7 @@ var crs = new L.Proj.CRS('EPSG:3006',
 	});
 
 L.tileLayer.wms('http://geodatatest.havochvatten.se/geoservices/ows', {
-	layers: 'hav-fisketsgeografier:havet-ostersjons-delomraden',
+	layers: 'hav-bakgrundskartor:hav-grundkarta',
 	format: 'image/png',
 	maxZoom: 14,
 	minZoom: 0,


### PR DESCRIPTION
The layer name used in the wms example appear to be obsolete and the wms example doesnt
work. I Updated the layer name to another layer in the same wms service that
makes the wms example work again.