### PR TITLE
Update proj4 to support custom GeoJSON layers

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -155,6 +155,11 @@
 
 	L.Proj.GeoJSON = L.GeoJSON.extend({
 		initialize: function(geojson, options) {
+			options = this.addCRS(geojson, options);
+			L.GeoJSON.prototype.initialize.call(this, geojson, options);
+		},
+		
+		addCRS: function(geojson, options) {
 			if (geojson.crs && geojson.crs.type === 'name') {
 				var crs = new L.Proj.CRS(geojson.crs.properties.name);
 				options = options || {};
@@ -163,7 +168,7 @@
 					return crs.projection.unproject(point);
 				};
 			}
-			L.GeoJSON.prototype.initialize.call(this, geojson, options);
+			return options;
 		}
 	});
 


### PR DESCRIPTION
I created a new function to the L.Proj.GeoJSON prototype called addCRS which contains all of the code to initialize custom CRS in a GeoJSON layer to allow custom GeoJSON layers with custom initializations and custom functions to incorporate the Proj.GeoJSON functionality inside the custom GeoJSON layer without reference the original GeoJSON prototype initialization.

example: 

```
customGeoJSON = L.GeoJSON.extend({
    initialize: function(geojson, options) {
        L.Proj.GeoJSON.prototype.addCRS.call(this, geojson, options);
        //Continue with custom initialization for layer

    }
})
```
