### PR TITLE
update package.json to work with beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/kartena/Proj4Leaflet/issues"
   },
   "dependencies": {
-    "leaflet": "~0.7.0",
-    "proj4": "~2.0.0"
+    "leaflet": "^1.0.0-beta.2",
+    "proj4": "^2.3.10"
   }
 }


### PR DESCRIPTION
Fix the package.json so that `npm install git+https://git@github.com/kartena/proj4leaflet.git/#leaflet-proj-refactor`, works properly. Meaning that it will install the correct proj4 and leaflet-version.
