### PR TITLE
Fixed zoom returning NaN if passed in scale bigger than scales defined

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -126,9 +126,10 @@
 		},
 
 		zoom: function(scale) {
-			// Find closest number in this._scales, down 
+			// Find closest number in this._scales, down
 			var downScale = this._closestElement(this._scales, scale),
 				downZoom = this._scales.indexOf(downScale),
+				nextScale,
 				nextZoom,
 				scaleDiff;
 			// Check if scale is downScale => return array index
@@ -137,7 +138,11 @@
 			}
 			// Interpolate
 			nextZoom = downZoom + 1;
-			scaleDiff = this._scales[nextZoom] - downScale;
+			nextScale = this._scales[nextZoom];
+			if (nextScale === undefined) {
+				return Infinity;
+			}
+			scaleDiff = nextScale - downScale;
 			return (scale - downScale) / scaleDiff + downZoom;
 		},
 

--- a/test/specs.js
+++ b/test/specs.js
@@ -135,7 +135,8 @@ describe('L.Proj.CRS', function() {
 			worldSize *= 2;
 		}
 	});
-	it('convert zoom to scale and viceversa and return the same values', function () {
+
+	it('converts zoom to scale and vice versa and returns the same values', function () {
 		 var crs = new L.Proj.CRS('EPSG:3006',
 				'+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
 		{
@@ -150,5 +151,14 @@ describe('L.Proj.CRS', function() {
 		expect(crs.zoom(crs.scale(1/8191))).toBeCloseTo(1/8191, 6);
 		expect(crs.zoom(crs.scale(0.5))).toBe(0.5);
 		expect(crs.zoom(crs.scale(0.51))).toBe(0.51);
+	});
+
+	it('converts scale to zoom and returns Infinity if the scale passed in is bigger than maximum scale', function () {
+		var crs = new L.Proj.CRS('EPSG:3006', '', {
+			scales: [1, 2, 3]
+		});
+
+		expect(crs.zoom(4)).toBe(Infinity);
+		expect(crs.zoom(Infinity)).toBe(Infinity);
 	});
 });


### PR DESCRIPTION
Fixed the issue with `L.Proj.CRS.zoom()` returning `NaN` when used with a scale factor of `Infinity` that should return `Infinity`. Discussed here https://github.com/Leaflet/Leaflet/issues/4566