### PR TITLE
Set proj4 dependecy to ~2.3 instead of ^2 because of #139

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Proj4Leaflet",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/kartena/Proj4Leaflet",
   "authors": [
     "Per Liedman <per.liedman@kartena.se> (https://github.com/perliedman/)",
@@ -48,6 +48,6 @@
     "tests"
   ],
   "dependencies": {
-    "proj4": "^2.3.14"
+    "proj4": "~2.3.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proj4leaflet",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Smooth Proj4js integration with Leaflet",
   "main": "src/proj4leaflet.js",
   "directories": {
@@ -48,7 +48,7 @@
     "url": "https://github.com/kartena/Proj4Leaflet/issues"
   },
   "dependencies": {
-    "proj4": "^2.3.14"
+    "proj4": "~2.3.14"
   },
   "devDependencies": {
     "mocha": "^3.2.0",


### PR DESCRIPTION
There is a problem when using proj4leaflet with proj4 2.4.x together with webpack and bable. 
This patch sets the dependency on proj4 to ~2.3 instead of ^2 to quick fix that problem. 

The deeper issues still needs to be addressed, see #139.