### PR TITLE
Work around Webpack import problem

### DIFF
--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -11,7 +11,6 @@
 		// the actual object as `.default`; if the modules have `.default`, use
 		// that instead.  See issue #139 for details.
 		module.exports = factory(
-			(L.default ? L.default : L),
 			(proj4.default ? proj4.default : proj4)
 		);
 	} else {
@@ -21,7 +20,13 @@
 		factory(window.L, window.proj4);
 	}
 }(function (L, proj4) {
-
+	if (proj4.__esModule && proj4.default) {
+		// If proj4 was bundled as an ES6 module, unwrap it to get
+		// to the actual main proj4 object.
+		// See discussion in https://github.com/kartena/Proj4Leaflet/pull/147
+		proj4 = proj4.default;
+	}
+ 
 	L.Proj = {};
 
 	L.Proj._isProj4Obj = function(a) {

--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -7,7 +7,13 @@
 		// Node/CommonJS
 		L = require('leaflet');
 		proj4 = require('proj4');
-		module.exports = factory(L, proj4);
+		// When using Webpack, these modules may become ES6 modules that export
+		// the actual object as `.default`; if the modules have `.default`, use
+		// that instead.  See issue #139 for details.
+		module.exports = factory(
+			(L.default ? L.default : L),
+			(proj4.default ? proj4.default : proj4)
+		);
 	} else {
 		// Browser globals
 		if (typeof window.L === 'undefined' || typeof window.proj4 === 'undefined')

--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -8,7 +8,6 @@
 		L = require('leaflet');
 		proj4 = require('proj4');
 		module.exports = factory(L, proj4);
-		);
 	} else {
 		// Browser globals
 		if (typeof window.L === 'undefined' || typeof window.proj4 === 'undefined')

--- a/src/proj4leaflet.js
+++ b/src/proj4leaflet.js
@@ -7,11 +7,7 @@
 		// Node/CommonJS
 		L = require('leaflet');
 		proj4 = require('proj4');
-		// When using Webpack, these modules may become ES6 modules that export
-		// the actual object as `.default`; if the modules have `.default`, use
-		// that instead.  See issue #139 for details.
-		module.exports = factory(
-			(proj4.default ? proj4.default : proj4)
+		module.exports = factory(L, proj4);
 		);
 	} else {
 		// Browser globals


### PR DESCRIPTION
**Note:** The patch here is suboptimal; see https://github.com/akx/Proj4Leaflet/commit/a1c61f9e5e57c72ab59a89dc39b78518b538f995 for a better one!

When using Webpack, `leaflet` and `proj4` may be exported as ES6 style modules that export the actual object as `.default`; so, if the modules have `.default`, use that.

The symptom for this issue is "TypeError: proj4.defs is not a function" (for ease of googling).

This is related to
* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15663
* #139